### PR TITLE
feat: スタッフ追加（is_ryo）

### DIFF
--- a/src/lib/data/staffMember.ts
+++ b/src/lib/data/staffMember.ts
@@ -73,4 +73,9 @@ export const memberInfos = [
     image: "engineerYodaka.jpg",
     href: "https://x.com/engineerYodaka",
   },
+  {
+    name: "is_ryo",
+    image: "is_ryo.jpg",
+    href: "https://x.com/is_ryo",
+  },
 ] satisfies Member[];


### PR DESCRIPTION
## 概要

- スタッフ一覧に `is_ryo` を追加
  - 画像は既に入っていたので差分はありません  

## SS

![スクリーンショット 2024-09-30 19 01 17](https://github.com/user-attachments/assets/2e19a98f-ed5b-402b-a983-49b633e91599)
