### PR TITLE
タイムテーブルのKeynoteにラベル追加

### DIFF
--- a/src/components/session-time-table/SessionCardLabels.tsx
+++ b/src/components/session-time-table/SessionCardLabels.tsx
@@ -13,7 +13,7 @@ const SessionCardLabels = ({ labels, bgColor }: SessionCardLabels) => {
           // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
           key={`${label}-${index}`}
           label={label}
-          bgColor={bgColor}
+          bgColor={label === "Keynote" ? "bg-[#f3a200]" : bgColor}
         />
       ))}
     </div>

--- a/src/lib/data/session.ts
+++ b/src/lib/data/session.ts
@@ -330,7 +330,7 @@ export const TIME_TABLE_DATA: CardInfo[][] = [
       content: [SESSION_LIST.s_001],
       size: "md:col-span-3",
       track: "Track1",
-      labels: ["トグルルーム"],
+      labels: ["トグルルーム", "セッション", "Keynote"],
     },
     {
       type: "info",


### PR DESCRIPTION
- タイムテーブルにラベル追加
  - `セッション` の入れ忘れ
  - `Keynote` を追加
    - オレンジ系の色を追加
 
<img width="1201" alt="スクリーンショット 2024-11-03 13 57 34" src="https://github.com/user-attachments/assets/68a59f65-235e-421a-95fc-3f01172dbac2">
